### PR TITLE
Fixed game crash related to Skin Feature

### DIFF
--- a/src/main/java/com/vicmatskiv/pointblank/feature/SkinFeature.java
+++ b/src/main/java/com/vicmatskiv/pointblank/feature/SkinFeature.java
@@ -37,7 +37,7 @@ public class SkinFeature extends ConditionalFeature {
    public static ResourceLocation getTexture(ItemStack itemStack) {
       Features.EnabledFeature enabledSkinTexture = Features.getFirstEnabledFeature(itemStack, SkinFeature.class);
       if(enabledSkinTexture != null && enabledSkinTexture.feature() instanceof SkinFeature feature) {
-         if (!feature.conditions.isEmpty()) {
+         if (feature.conditions != null && !feature.conditions.isEmpty()) {
             Predicate<ConditionContext> condition = (ctx) -> true;
             for (var entry : feature.conditions.entrySet()) {
                GunClientState gunState = GunClientState.getMainHeldState(ClientUtils.getClientPlayer());


### PR DESCRIPTION
Hotfix for a game crash that happens when having a Skin Feature on a gun that does not use the new skins array and then attempting to attach something onto it that meets the conditions of said Skin Feature.