### PR TITLE
Fix `ConcurrentModificationException` crashes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+	"java.configuration.updateBuildConfiguration": "interactive"
+}

--- a/src/main/java/mod/pbj/client/render/GunItemRenderer.java
+++ b/src/main/java/mod/pbj/client/render/GunItemRenderer.java
@@ -455,12 +455,22 @@ public class GunItemRenderer extends GeoItemRenderer<GunItem> implements RenderP
             position = position.add(v1Position);
             EffectRenderContext context = (new EffectRenderContext()).withPoseStack(poseStack).withPosition(new Vec3(position.x, position.y, position.z)).withVertexBuffer(buffer).withLightColor(packedLight);
 
-            for(MuzzleFlashEffect effect : this.gunClientState.getMuzzleFlashEffects()) {
-               UUID effectId = EffectRegistry.getEffectId(effect.getName());
-               if (Objects.equal(effectId, RenderPass.getEffectId())) {
-                  effect.render(context);
-               }
-            }
+            // for(MuzzleFlashEffect effect : this.gunClientState.getMuzzleFlashEffects()) {
+            //    UUID effectId = EffectRegistry.getEffectId(effect.getName());
+            //    if (Objects.equal(effectId, RenderPass.getEffectId())) {
+            //       effect.render(context);
+            //    }
+            // }
+
+			// avoid ConcurrentModificationException by not using ArrayList.iterator()
+			final var muzzleFlashEffects = this.gunClientState.getMuzzleFlashEffects();
+			for (int i = 0; i < muzzleFlashEffects.size(); ++i) {
+				final var effect = muzzleFlashEffects.get(i);
+				UUID effectId = EffectRegistry.getEffectId(effect.getName());
+				if (Objects.equal(effectId, RenderPass.getEffectId())) {
+					effect.render(context);
+				}
+			}
          }
 
       }


### PR DESCRIPTION
This occurred with Vivecraft present, when firing any gun in automatic fire. Whether Vivecraft or GeckoLib is the cause of the exceptions, I'm not sure. It may be possible that Vivecraft multithreads the rendering process (for the left and right eyes), and somewhere somehow the muzzle flash effects list is updated in between the left & right render passes (one out of the two problems).

This never happened with the latest Vic's Point Blank jar for Forge 1.20.1. Maybe the decompilation did something weird. Regardless, these changes stopped the crashes. This could help any other players using Vivecraft with PB:J.